### PR TITLE
Add JSON Schema and CI validation for data.json

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,34 @@
+name: Validate data.json
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Regenerate data artifacts from doc_export.html
+        run: python data/convert_doc.py
+
+      - name: Check committed artifacts match regenerated output
+        run: |
+          git diff --exit-code \
+            data/data.json \
+            data/directory_data.json \
+            data/directory_structure.yaml \
+            dashboard/doc_styles.css
+
+      - name: Validate data.json against schema
+        run: python data/validate.py

--- a/data/convert_doc.py
+++ b/data/convert_doc.py
@@ -197,6 +197,8 @@ def parse_google_doc_html(html_path, output_css_path=None):
                 current_h2_obj = None
                 
         elif el.name == 'h2':
+            if not text:
+                continue
             if current_h1_obj and not current_h1_obj.get("special"):
                 current_h2_obj = {
                     "title": text,
@@ -204,7 +206,7 @@ def parse_google_doc_html(html_path, output_css_path=None):
                 }
                 current_h1_obj["subsections"].append(current_h2_obj)
             else:
-                current_h2_obj = None 
+                current_h2_obj = None
 
         elif el.name in ['p', 'ul', 'ol']:
             if current_h1_obj and current_h1_obj.get("special"):

--- a/data/data.json
+++ b/data/data.json
@@ -103,10 +103,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "1.2 Camera Type & Model",
                     "items": [
                         {
@@ -151,10 +147,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "1.3 Per take Sensor Metadata",
                     "items": [
                         {
@@ -190,10 +182,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "1.4 Per Camera Lens Specifications",
@@ -232,10 +220,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "1.5 Lens Encoder Tracking Data",
@@ -343,10 +327,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "2.2 Overhead & Wide-Angle BTS Coverage",
                     "items": [
                         {
@@ -376,10 +356,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "2.3 Real-World Depth Information",
@@ -658,10 +634,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "4.2 HDRIs",
                     "items": [
                         {
@@ -722,10 +694,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "4.4 DMX/Lighting Control Metadata",
@@ -997,10 +965,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "5.6 Set Reference Photography",
                     "items": [
                         {
@@ -1031,10 +995,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "5.7 Costume, Face Marker, and T-Pose Reference",
                     "items": [
                         {
@@ -1062,10 +1022,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "5.8 Reference of Vehicles, Props, Production Locations",
@@ -1101,10 +1057,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -1147,10 +1099,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "6.2 DIT Specs",
                     "items": [
                         {
@@ -1185,10 +1133,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "6.3 Lens Specification",
                     "items": [
                         {
@@ -1218,10 +1162,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -1270,10 +1210,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "7.2 Concept Art, Lookdev, Character Designs, R&D, Storyboards",
                     "items": [
                         {
@@ -1308,10 +1244,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -1349,10 +1281,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "8.2 Performance Capture Facial Tracking",
                     "items": [
                         {
@@ -1378,10 +1306,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "8.3 Hand/Finger Tracking",
@@ -1417,10 +1341,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "8.4 Raw Animation Data & Retargeting Settings",
                     "items": [
                         {
@@ -1454,10 +1374,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "8.5 Motion Capture Volume Data",
                     "items": [
                         {
@@ -1482,10 +1398,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -1571,10 +1483,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "9.3 IMU Data",
                     "items": [
                         {
@@ -1606,10 +1514,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -1649,10 +1553,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "10.2 Display Frustum Calibration",
                     "items": [
                         {
@@ -1679,10 +1579,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "10.3 Colour Profile & Brightness Settings",
@@ -1717,10 +1613,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "10.4 Latency Data",
                     "items": [
                         {
@@ -1748,10 +1640,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "10.5 Plate vs. Real-Time Rendered Assets",
@@ -1784,10 +1672,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -1823,10 +1707,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "11.2 Virtual Production Operator Metadata",
                     "items": [
                         {
@@ -1852,10 +1732,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "11.3 On-Set Real-Time Adjustments",
@@ -1885,10 +1761,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -1928,10 +1800,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "12.2 Spatial Audio Tracking Metadata",
                     "items": [
                         {
@@ -1957,10 +1825,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "12.3 Lip sync and character audio",
@@ -1992,10 +1856,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -2034,10 +1894,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "13.2 Mudmaps",
                     "items": [
                         {
@@ -2069,10 +1925,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "13.3 Storyboards, Previz, Techviz, Stuntviz",
@@ -2117,10 +1969,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "13.4 Art Department Assets",
@@ -2170,10 +2018,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -2212,10 +2056,6 @@
                     ]
                 },
                 {
-                    "title": "",
-                    "items": []
-                },
-                {
                     "title": "14.2 Lens Grid and Reference Specs",
                     "items": [
                         {
@@ -2247,10 +2087,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 }
             ]
         },
@@ -2286,10 +2122,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "15.2 Descriptive File Naming",
@@ -2335,10 +2167,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "title": "",
-                    "items": []
                 },
                 {
                     "title": "15.3 Review Tools",

--- a/data/schema.json
+++ b/data/schema.json
@@ -1,0 +1,192 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://ves-on-set-data.org/schema/data.schema.json",
+    "title": "VES On-Set VFX Data Collection Guide",
+    "description": "Schema for data.json produced by data/convert_doc.py from the canonical Google Doc.",
+    "type": "object",
+    "required": [
+        "version",
+        "publishDate",
+        "Introduction",
+        "Scope Definitions",
+        "VFX Types",
+        "Data Sets",
+        "Directory Structure",
+        "Reference Docs",
+        "Feedback"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$",
+            "description": "Semantic version of the source document."
+        },
+        "publishDate": {
+            "type": "string",
+            "format": "date",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "ISO-8601 publication date of the source document."
+        },
+        "Introduction": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/htmlBlock" },
+            "minItems": 1
+        },
+        "Scope Definitions": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    { "$ref": "#/$defs/htmlBlock" },
+                    { "$ref": "#/$defs/definitionsTable" }
+                ]
+            }
+        },
+        "VFX Types": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    { "$ref": "#/$defs/htmlBlock" },
+                    { "$ref": "#/$defs/definitionsTable" }
+                ]
+            }
+        },
+        "Data Sets": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/section" }
+        },
+        "Directory Structure": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    { "$ref": "#/$defs/htmlBlock" },
+                    {
+                        "type": "object",
+                        "required": ["type"],
+                        "additionalProperties": false,
+                        "properties": {
+                            "type": { "const": "tree_view" }
+                        }
+                    }
+                ]
+            }
+        },
+        "Reference Docs": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/htmlBlock" },
+            "minItems": 1
+        },
+        "Feedback": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/htmlBlock" },
+            "minItems": 1
+        }
+    },
+    "$defs": {
+        "htmlBlock": {
+            "type": "object",
+            "required": ["html"],
+            "additionalProperties": false,
+            "properties": {
+                "html": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "definitionsTable": {
+            "description": "Key-value definitions table where each key is a term and the value is its definition (string) or a list of related terms.",
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "oneOf": [
+                    { "type": "string", "minLength": 1 },
+                    {
+                        "type": "array",
+                        "items": { "type": "string", "minLength": 1 },
+                        "minItems": 1
+                    }
+                ]
+            }
+        },
+        "section": {
+            "type": "object",
+            "required": ["title", "subsections"],
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "subsections": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/subsection" }
+                }
+            }
+        },
+        "subsection": {
+            "type": "object",
+            "required": ["title", "items"],
+            "additionalProperties": false,
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "items": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/dataEntry" }
+                }
+            }
+        },
+        "dataEntry": {
+            "description": "A single data-collection entry inside a subsection.",
+            "type": "object",
+            "required": [
+                "Data Collected",
+                "Description",
+                "Usage",
+                "Scope",
+                "Creator",
+                "Consumer",
+                "VFXTypes"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "Data Collected": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 },
+                    "minItems": 1
+                },
+                "Description": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "Usage": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "Scope": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 },
+                    "minItems": 1
+                },
+                "Creator": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 },
+                    "minItems": 1
+                },
+                "Consumer": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 },
+                    "minItems": 1
+                },
+                "VFXTypes": {
+                    "type": "array",
+                    "items": { "type": "string", "minLength": 1 },
+                    "minItems": 1
+                }
+            }
+        }
+    }
+}

--- a/data/validate.py
+++ b/data/validate.py
@@ -1,0 +1,53 @@
+"""Validate data/data.json against data/schema.json.
+
+Run from the repository root:
+    python data/validate.py
+
+Exits with code 0 if data.json conforms to the schema, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+REPO = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO / "data" / "schema.json"
+DATA_PATH = REPO / "data" / "data.json"
+
+
+def main() -> int:
+    with SCHEMA_PATH.open() as f:
+        schema = json.load(f)
+    with DATA_PATH.open() as f:
+        data = json.load(f)
+
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+
+    if errors:
+        for err in errors:
+            path = "/".join(str(p) for p in err.absolute_path) or "<root>"
+            print(f"[{path}] {err.message}", file=sys.stderr)
+        print(f"\nFAIL: {len(errors)} schema violation(s)", file=sys.stderr)
+        return 1
+
+    sections = data.get("Data Sets", [])
+    subsections = sum(len(s.get("subsections", [])) for s in sections)
+    items = sum(
+        len(sub.get("items", []))
+        for s in sections
+        for sub in s.get("subsections", [])
+    )
+    print(
+        f"OK: data.json conforms to schema "
+        f"({len(sections)} sections, {subsections} subsections, {items} items)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 PyYAML
+jsonschema


### PR DESCRIPTION
Treats `data.json` as a spec — adds a JSON Schema, a validator, and a GitHub Actions workflow that regenerates data from `doc_export.html` and validates on every PR, so the parser and the committed artifact cannot silently drift.

While wiring this up the schema surfaced 43 empty-titled subsections in `data.json` caused by `convert_doc.py` appending a subsection for every `<h2>` element including styling-only ones. This PR includes a one-line skip for empty `<h2>`s and regenerates `data.json`; CI is green after that fix. The source Google Doc likely still contains those empty `<h2>`s — I don't have edit access there.

The schema is strict by default (`additionalProperties: false` at the top level and on data entries) so future field additions surface as CI failures and prompt a schema bump alongside the data change. Easy to relax to `true` if you'd rather have the schema document the shape without constraining it.

Files:
- `data/schema.json` — draft-2020-12 schema
- `data/validate.py` — local + CI validator (run via `python data/validate.py`)
- `.github/workflows/validate.yml` — round-trip + validate on push to main and on every PR
- `data/convert_doc.py` — skip empty `<h2>` elements
- `data/data.json` — regenerated (43 phantom subsections removed)
- `requirements.txt` — added `jsonschema`
