### PR TITLE
Adding a PDF download link to the banner

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -20,6 +20,9 @@
             <img src="ves-banner.jpg" alt="VES Banner" class="header-banner">
             <h1><a href="https://vesglobal.org/" target="_blank" rel="noopener" aria-label="VES website"><img height=40 src="ves-logo.png" alt="VES Logo" class="header-logo"></a> VES On-Set VFX Data Collection and
                 Usage Guide <span id="version-info" class="version-info"></span></h1>
+            <a class="header-pdf-link"
+                href="https://ves-on-set-data.org/data/On-Set_VFX_Data_Collection_and_Usage_Guide_v1.1.0.pdf"
+                target="_blank" rel="noopener" aria-label="Download the latest PDF version of the guide">Download PDF</a>
         </div>
     </header>
 

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -72,6 +72,26 @@ body {
     opacity: 0.8;
 }
 
+.header-pdf-link {
+    margin-left: auto;
+    /* Push to right */
+    flex-shrink: 0;
+    align-self: center;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--accent-color);
+    text-decoration: none;
+    border: 1px solid var(--accent-color);
+    border-radius: 4px;
+    padding: 0.5rem 0.9rem;
+    transition: background 0.2s, color 0.2s;
+}
+
+.header-pdf-link:hover {
+    background: var(--accent-color);
+    color: var(--bg-color);
+}
+
 .app-container {
     display: flex;
     flex: 1;
@@ -599,7 +619,8 @@ h1 {
     #filter-container,
     .tree-controls,
     .header-banner,
-    .header-logo {
+    .header-logo,
+    .header-pdf-link {
         display: none !important;
     }
 


### PR DESCRIPTION
Towards #5.

Adds an always-visible "Download PDF" link in the banner, pointing at the latest guide PDF (v1.1.0) — same URL convention as the existing link in the Introduction. Styled with the existing accent colour, and hidden in print alongside the banner and logo.

The other half of #5 — links to every PDF version under Reference Docs — is intentionally left out: that tab is generated into `data.json` from the canonical Google Doc, so a direct edit would be overwritten on the next regeneration. Those entries are best added to the Google Doc source by a maintainer; happy to help wire it up once they're in.
